### PR TITLE
SQL::Makerの最新版と組みあわせると、INSERT/REPLACEがsyntax errorとなるらしいです。

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ requires 'Data::Page';
 requires 'DBI';
 requires 'DBIx::Inspector' => '0.03';
 requires 'DBIx::TransactionManager' => '1.06';
-requires 'SQL::Maker' => 0.08;
+requires 'SQL::Maker' => 0.14;
 requires 'Data::Page::NoTotalEntries' => '0.02';
 
 author_tests('xt');

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -203,7 +203,7 @@ sub _last_insert_id {
 sub _insert {
     my ($self, $table_name, $args, $prefix) = @_;
 
-    $prefix ||= 'INSERT';
+    $prefix ||= 'INSERT INTO';
     my $table = $self->schema->get_table($table_name);
     if (! $table) {
         local $Carp::CarpLevel = $Carp::CarpLevel + 1;

--- a/lib/Teng/Plugin/Replace.pm
+++ b/lib/Teng/Plugin/Replace.pm
@@ -17,7 +17,7 @@ sub replace {
         $args->{$col} = $table->call_deflate($col, $args->{$col});
     }
 
-    my ($sql, @binds) = $self->sql_builder->insert( $table_name, $args, { prefix => 'REPLACE' } );
+    my ($sql, @binds) = $self->sql_builder->insert( $table_name, $args, { prefix => 'REPLACE INTO' } );
     $self->_execute($sql, \@binds, $table_name);
 
     my $pk = $table->primary_keys();


### PR DESCRIPTION
テストは以下のようにこけるようです。

t/002_common/012_replace.t ........................... @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@@@@ Teng 's Exception @@@@@
Reason  : DBD::SQLite::db prepare failed: near ""mock_basic"": syntax error at /Users/yoshimi/project/perl/p5-Teng/blib/lib/Teng.pm line 176.

SQL     : REPLACE "mock_basic"
          ("name", "id")
          VALUES (?, ?)
BIND    : $VAR1 = [
          'ruby',
          1
        ];

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 at /Users/yoshimi/project/perl/p5-Teng/blib/lib/Teng/Plugin/Replace.pm line 21
t/002_common/012_replace.t ........................... 1/?     # Child (replace mock_basic data) exited without calling finalize()
