### PR TITLE
columns オプションの追加

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -334,7 +334,7 @@ sub search {
 
     my ($sql, @binds) = $self->sql_builder->select(
         $table_name,
-        $table->columns,
+        $opt->{columns} || $table->columns,
         $where,
         $opt
     );

--- a/t/002_common/007_search.t
+++ b/t/002_common/007_search.t
@@ -82,4 +82,10 @@ subtest 'search with non-exist table' => sub {
     like $@, qr/No such table must_not_exist/;
 };
 
+subtest 'search with select' => sub {
+    my $r = $db->single('mock_basic', {}, { columns => ['name', \'id * 2 as double_id'], order_by => ['id'] });
+    is $r->name, 'perl';
+    is $r->get_column('double_id'), 2;
+};
+
 done_testing;


### PR DESCRIPTION
search/single の際に、取ってくるカラムを指定したり、関数を使いたい時のために、あると便利かと思います。

my $r = $teng->single('table', {}, {columns => ['name', \"date('create_time') as create_date" ]});
print $r->name;
print $r->get_column('create_date');

のように使いたいです。
