### PR TITLE
specify columns support for search_with_pager and lookup methods

### DIFF
--- a/lib/Teng/Plugin/Lookup.pm
+++ b/lib/Teng/Plugin/Lookup.pm
@@ -15,7 +15,7 @@ sub lookup {
 
     my $cond = join ' AND ', map {"$_ = ?"} @sorted_keys;
     my $sql = sprintf('SELECT %s FROM %s WHERE %s %s',
-               join(',', @{$table->{columns}}),
+               join(',', @{$opt->{columns} || $table->{columns}}),
                $table_name,
                $cond,
                $opt->{for_update} ? 'FOR UPDATE' : '',

--- a/lib/Teng/Plugin/Pager.pm
+++ b/lib/Teng/Plugin/Pager.pm
@@ -22,7 +22,7 @@ sub search_with_pager {
 
     my ($sql, @binds) = $self->sql_builder->select(
         $table_name,
-        $table->columns,
+        ($opt->{columns} || $table->{columns}),
         $where,
         +{
             %$opt,

--- a/lib/Teng/Plugin/Pager/MySQLFoundRows.pm
+++ b/lib/Teng/Plugin/Pager/MySQLFoundRows.pm
@@ -18,7 +18,7 @@ sub search_with_pager {
 
     my ($sql, @binds) = $self->sql_builder->select(
         $table_name,
-        $table->columns,
+        ($opt->{columns} || $table->{columns}),
         $where,
         +{
             %$opt,

--- a/t/001_basic/025_pager.t
+++ b/t/001_basic/025_pager.t
@@ -34,5 +34,19 @@ subtest 'last' => sub {
     is $pager->prev_page, 10;
 };
 
+subtest 'simple_with_columns' => sub {
+    my ($rows, $pager) = $db->search_with_pager(mock_basic => {}, {columns => [qw/id/], rows => 3, page => 1});
+    is join(',', map { $_->id } @$rows), '1,2,3';
+    is_deeply $rows->[0]->get_columns, +{ id => 1 };
+    is_deeply $rows->[1]->get_columns, +{ id => 2 };
+    is_deeply $rows->[2]->get_columns, +{ id => 3 };
+    is $pager->entries_per_page(), 3;
+    is $pager->entries_on_this_page(), 3;
+    is $pager->current_page(), 1;
+    is $pager->next_page, 2, 'next_page';
+    ok $pager->has_next, 'has_next';
+    is $pager->prev_page, undef;
+};
+
 done_testing;
 

--- a/t/001_basic/028_lookup.t
+++ b/t/001_basic/028_lookup.t
@@ -31,5 +31,18 @@ subtest 'lookup method' => sub {
     };
 };
 
+subtest 'lookup_with_columns' => sub {
+    $db_basic->insert('mock_basic', => +{
+        id   => 2,
+        name => 'ruby',
+    });
+
+    my $row = $db_basic->lookup('mock_basic', +{id => 2}, { columns => [qw/id/]});
+    isa_ok $row, 'Mock::Basic::Row::MockBasic';
+    is_deeply $row->get_columns, +{
+        id => 2,
+    };
+};
+
 done_testing;
 

--- a/xt/mysql/pager_mysql_found_rows.t
+++ b/xt/mysql/pager_mysql_found_rows.t
@@ -32,6 +32,19 @@ subtest 'last' => sub {
     is $pager->previous_page, 10;
 };
 
+subtest 'simple_with_columns' => sub {
+    my ($rows, $pager) = $db->search_with_pager(mock_basic => {}, {columns => [qw/id/], rows => 3, page => 1});
+    is join(',', map { $_->id } @$rows), '1,2,3';
+    is_deeply $rows->[0]->get_columns, +{ id => 1 };
+    is_deeply $rows->[1]->get_columns, +{ id => 2 };
+    is_deeply $rows->[2]->get_columns, +{ id => 3 };
+    is $pager->total_entries(), 32;
+    is $pager->entries_per_page(), 3;
+    is $pager->current_page(), 1;
+    is $pager->next_page, 2, 'next_page';
+    is $pager->previous_page, undef;
+};
+
 done_testing;
 
 


### PR DESCRIPTION
どれもPluginなんですが、本体の各種メソッドと同様にcolumnsをサポートしといたほうが
混乱は少ないかなと
