### PR TITLE
(Dumper) Sort columns in their correct order

### DIFF
--- a/lib/Teng/Schema/Dumper.pm
+++ b/lib/Teng/Schema/Dumper.pm
@@ -1,7 +1,7 @@
 package Teng::Schema::Dumper;
 use strict;
 use warnings;
-use DBIx::Inspector 0.03;
+use DBIx::Inspector 0.04;
 use Carp ();
 
 sub dump {
@@ -20,7 +20,11 @@ sub dump {
         $ret .= sprintf("    name '%s';\n", $table_info->name);
         $ret .= sprintf("    pk %s;\n", join ',' , map { q{'}.$_->name.q{'} } $table_info->primary_key);
         $ret .= "    columns (\n";
-        for my $col ($table_info->columns) {
+        my @columns = $table_info->columns;
+        if (@columns && $columns[0]->get(my $key = 'ORDINAL_POSITION')) {
+            @columns = sort { $a->get($key) <=> $b->get($key) } @columns;
+        }
+        for my $col (@columns) {
             if ($col->data_type) {
                 $ret .= sprintf("        {name => '%s', type => %s},\n", $col->name, $col->data_type);
             } else {

--- a/xt/mysql/004_schema_dumper.t
+++ b/xt/mysql/004_schema_dumper.t
@@ -38,7 +38,7 @@ my $db = Mock::DB->new(dbh => $dbh);
 my $user = $db->schema->get_table('user');
 is($user->name, 'user');
 is(join(',', @{$user->primary_keys}), 'user_id');
-is(join(',', sort @{$user->columns}), join(',', sort qw/user_id name email created_on/));
+is(join(',', @{$user->columns}), join(',', qw/user_id name email created_on/));
 is_deeply $user->sql_types, +{
     user_id    => 4,
     name       => 12,


### PR DESCRIPTION
Fixed that when using DBD::mysql, the column information of each table was in a random order.
