### PR TITLE
lookup allow $where as arrayref

### DIFF
--- a/bench/lookup_vs_single.pl
+++ b/bench/lookup_vs_single.pl
@@ -37,10 +37,11 @@ my $row = $db->single('user', { id => 1 });
 my $dbh = $db->dbh;
 
 cmpthese(10000 => +{
-    dbi           => sub {$dbh->selectrow_hashref('SELECT id,name,age FROM user where id = ?', undef, 1)},
-    single        => sub {$db->single('user', +{id => 1})},
-    single_by_sql => sub {$db->single_by_sql('SELECT id,name,age FROM user WHERE id = ?', [1], 'user')},
-    lookup        => sub {$db->lookup('user', +{id => 1})},
+    dbi             => sub {$dbh->selectrow_hashref('SELECT id,name,age FROM user where id = ?', undef, 1)},
+    single          => sub {$db->single('user', +{id => 1})},
+    single_by_sql   => sub {$db->single_by_sql('SELECT id,name,age FROM user WHERE id = ?', [1], 'user')},
+    lookup          => sub {$db->lookup('user', +{id => 1})},
+    lookup_arrayref => sub {$db->lookup('user', [id => 1])},
 }, 'all');
 
 __END__

--- a/lib/Teng/Plugin/Lookup.pm
+++ b/lib/Teng/Plugin/Lookup.pm
@@ -11,11 +11,22 @@ sub lookup {
     my $table = $self->{schema}->get_table( $table_name );
     Carp::croak("No such table $table_name") unless $table;
 
-    my @sorted_keys = sort keys %$where;
+    my (@keys, $values);
+    if ( ref $where eq 'ARRAY' ) {
+        my @w = @$where;
+        while (my ($key, $val) = splice @w, 0, 2) {
+            push @keys, $key;
+            push @$values, $val;
+        }
+    }
+    else {
+        @keys = sort keys %$where;
+        $values = [@$where{@keys}];
+    }
 
     my $dbh = $self->dbh;
     my $columns = $self->_get_select_columns($table, $opt);
-    my $cond = join ' AND ', map {$dbh->quote_identifier($_) . ' = ?'} @sorted_keys;
+    my $cond = join ' AND ', map {$dbh->quote_identifier($_) . ' = ?'} @keys;
     my $sql = sprintf('SELECT %s FROM %s WHERE %s %s',
                join(',', map { ref $_ ? $$_ : $_ } @{$columns}),
                $table_name,
@@ -23,7 +34,7 @@ sub lookup {
                $opt->{for_update} ? 'FOR UPDATE' : '',
            );
 
-    my $sth = $self->_execute($sql, [@$where{@sorted_keys}]);
+    my $sth = $self->_execute($sql, $values);
     my $row = $sth->fetchrow_hashref('NAME_lc');
 
     return unless $row;

--- a/t/001_basic/028_lookup.t
+++ b/t/001_basic/028_lookup.t
@@ -29,6 +29,32 @@ subtest 'lookup method' => sub {
         name      => 'perl',
         delete_fg => 0,
     };
+    $row->delete;
+};
+
+subtest 'lookup method(arrayref)' => sub {
+    $db_basic->insert('mock_basic', => {
+        id   => 1,
+        name => 'perl',
+    });
+
+    my $row = $db_basic->lookup('mock_basic', [id => 1]);
+    isa_ok $row, 'Mock::Basic::Row::MockBasic';
+    is_deeply $row->get_columns, +{
+        id        => 1,
+        name      => 'perl',
+        delete_fg => 0,
+    };
+
+    # multiple key
+    $row = $db_basic->lookup('mock_basic', [id => 1, name => 'perl']);
+    isa_ok $row, 'Mock::Basic::Row::MockBasic';
+    is_deeply $row->get_columns, +{
+        id        => 1,
+        name      => 'perl',
+        delete_fg => 0,
+    };
+    $row->delete;
 };
 
 subtest 'lookup_with_columns' => sub {


### PR DESCRIPTION
SQL::Makerのほうだと、$whereは

hashref
arrayref
object as SQL::Maker::Condition

のみっつがokになっていて、SQL::Maker::Conditionはさすがにサポートしなくて
いいと思うのですが、arrayrefも受け付けてくれると混乱が少ないかなと思います。
