### PR TITLE
fix document bug of get_columns.

### DIFF
--- a/lib/Teng/Row.pm
+++ b/lib/Teng/Row.pm
@@ -203,7 +203,7 @@ get a column value from a row object.
 
 =item $row->get_columns
 
-    my %data = $row->get_columns;
+    my $data = $row->get_columns;
 
 Does C<get_column>, for all column values.
 


### PR DESCRIPTION
Teng::Rowのget_columns は hash ref を返しますが、ドキュメントではhashで受け取るようになっているので、実装に合わせてドキュメントを修正しました。
