### PR TITLE
_execute 内の$vのチェックの変更

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -231,7 +231,7 @@ sub _execute {
         $sth = $self->dbh->prepare($sql);
         my $i = 1;
         for my $v ( @{ $binds || [] } ) {
-            $sth->bind_param( $i++, ref($v) ? @$v : $v );
+            $sth->bind_param( $i++, ref($v) eq 'ARRAY' ? @$v : $v );
         }
         $sth->execute();
     };


### PR DESCRIPTION
ref($V) しか見ていないので、overload '""' => されているようなオブジェクトが来たときに、arrayでデリファレンスしようとして、死んでしまっています。
