### PR TITLE
Limit the dumper max depth in exception stack trace.

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -590,6 +590,7 @@ sub handle_error {
     my ($self, $stmt, $bind, $reason) = @_;
     require Data::Dumper;
 
+    local $Data::Dumper::Maxdepth = 2;
     $stmt =~ s/\n/\n          /gm;
     Carp::croak sprintf <<"TRACE", $reason, $stmt, Data::Dumper::Dumper($bind);
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@


### PR DESCRIPTION
うっかり DateTime とか Teng のオブジェクトとかわたすとめっちゃでっかい Dump できて涙がでちゃうのです。
