### PR TITLE
bar has been added to the table mock_inflate.

### DIFF
--- a/t/999_regression/set_column_bug.t
+++ b/t/999_regression/set_column_bug.t
@@ -14,6 +14,7 @@ subtest 'set_column value un deflate bug' => sub {
         id   => 1,
         name => 'tsucchi',
         foo  => 'bar',
+        bar  => 'zzz',
     });
     isa_ok $row, 'Teng::Row';
     isa_ok $row->name, 'Mock::Inflate::Name';


### PR DESCRIPTION
https://github.com/nekokak/p5-Teng/pull/89 のためにテストのmock_inflateテーブルにbarカラムを追加したのですが、その影響でt/999_regression/set_column_bug.tがコケてしまっていたのでinsertの引数にbarを追加しました。
