### PR TITLE
fix problem when using Schema::Loader and method `new` is overrided

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -47,6 +47,7 @@ sub load_plugin {
 sub new {
     my $class = shift;
     my %args = @_ == 1 ? %{$_[0]} : @_;
+    my $loader = delete $args{loader};
 
     if ( my $mode = delete $args{mode} ) {
         warn "IMPORTANT: 'mode' option is DEPRECATED AND *WILL* BE REMOVED. PLEASE USE 'no_ping' option.\n";
@@ -63,8 +64,7 @@ sub new {
         %args,
     }, $class;
 
-    my @caller = caller(0);
-    if ($caller[0] ne 'Teng::Schema::Loader' && ! $self->schema) {
+    if (!$loader && ! $self->schema) {
         my $schema_class = $self->{schema_class};
         Class::Load::load_class( $schema_class );
         my $schema = $schema_class->instance;

--- a/lib/Teng/Schema/Loader.pm
+++ b/lib/Teng/Schema/Loader.pm
@@ -19,7 +19,7 @@ sub load {
         no strict 'refs'; @{"$namespace\::ISA"} = ('Teng');
     };
 
-    my $teng = $namespace->new(%args);
+    my $teng = $namespace->new(%args, loader => 1);
     my $dbh = $teng->dbh;
     unless ($dbh) {
         Carp::croak("missing mandatory parameter 'dbh' or 'connect_info'");


### PR DESCRIPTION
Teng::Schema::Loader->load dies soon when Teng#new is overrided by My::DB#new.

Then I wrote a patch.

In this patch, `caller()` is not used in constructor, but `load` option is assigned.
