### PR TITLE
Read inflated value after set_column

### DIFF
--- a/t/001_basic/011_inflate.t
+++ b/t/001_basic/011_inflate.t
@@ -71,15 +71,15 @@ subtest 'update row' => sub {
 
 
     subtest 'set_column & update' => sub  {
-        my $name = Mock::Inflate::Name->new(name => 'ruby');
-        $row->set_column(name => $name);
+        my $name = Mock::Inflate::Name->new(name => 'python');
+        $row->name($name);
         isa_ok $row->name, 'Mock::Inflate::Name';
-        is $row->name->name, 'ruby';
+        is $row->name->name, 'python';
         $row->update;
 
         my $updated = $db->single('mock_inflate',{id => 1});
         isa_ok $updated->name, 'Mock::Inflate::Name';
-        is $updated->name->name, 'ruby';
+        is $updated->name->name, 'python';
     };
 };
 


### PR DESCRIPTION
Error on reading inflated value after values by set_column() or column named setter.

```
$row->json_column({ data => 1 }); # json_column has deflate/inflate
$row->json_column; # raise error
```

以下、重要なので日本語で失礼します。
## 現状の仕様

現状の Teng は $row->update() 時に inflated な値 (オブジェクト) を渡すことができます。同じように $row->set_column(col => $inflated_value) や $row->col($inflated_value) をしてから update() を呼ぶことも可能です。

しかし $row->set_column(col => $inflated_value) したあと、$row->col() でセットした値を呼びだそうとすると、inflated な値を再度 inflate しようとするようです。
## 問題点
1. $row->{row_data} の扱いが曖昧。get_column の仕様から考えれば、row_data には生の値しか入らないはずだが、 $row->set_column(col => $inflated_value); $row->update; が (意図せず) 通ってしまう。
2. set_column() の仕様が明確ではない。get_column() には Note がついているが、このメソッドにはついていない。このメソッドも deflate するかしないかを明示すべき
3. update() 時、get_dirty_columns() で取得できる値に対して call_deflate を行うが、get_dirty_columns() は get_column() の値、すなわち生の値 (Note: This method does not inflate values.) を取得しており、潜在的に二重で deflate() するバグがある。
4. deflate しつつ値のセットだけを行うメソッドが存在しない
## このパッチの解決方法

仕様
- $row->{row_data} は生の値しか入れない (今まで通り)
- $row->set_column() は deflate しない。生の値しか扱わない (今まで通り) get_column (inflate しない) に対応
- $row->col($value) セッター は deflate する (非互換) $row->col アクセサ (inflate する) に対応

変更内容
- $row->col($value) 時に call_deflate を行って row_data などを設定しなおすように
- _dirty_columns の扱いを変更  → row_data と区別し、更新前の値 (inflated だったりする) をそのまま入れておくように
