### PR TITLE
Append warning to search_by_sql/search_named.

### DIFF
--- a/META.json
+++ b/META.json
@@ -31,7 +31,8 @@
             "Test::Mock::Guard" : "0",
             "Test::More" : "0.96",
             "Test::Requires" : "0",
-            "Test::SharedFork" : "0.15"
+            "Test::SharedFork" : "0.15",
+            "Test::Warn" : "0"
          }
       },
       "configure" : {
@@ -98,6 +99,7 @@
       "Atsushi Kobayashi <nekokak@gmail.com>",
       "Jun Kuriyama <kuriyama@s2factory.co.jp>",
       "Tokuhiro Matsuno <tokuhirom@gmail.com>",
+      "Masahiro Nagano <kazeburo@gmail.com>",
       "cho45 <cho45@lowreal.net>"
    ]
 }

--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ on build => sub {
     requires 'ExtUtils::MakeMaker', '6.36';
     requires 'Test::Mock::Guard';
     requires 'Test::More', '0.96';
+    requires 'Test::Warn';
     requires 'Test::Requires';
     requires 'Test::SharedFork', '0.15';
 };

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -569,6 +569,10 @@ sub single {
 sub search_by_sql {
     my ($self, $sql, $bind, $table_name) = @_;
 
+    if ($table_name && $sql !~ /$table_name/i) {
+        warn "'$table_name' is not appeared in sql: $sql";
+    }
+
     $table_name ||= $self->_guess_table_name( $sql );
     my $sth = $self->execute($sql, $bind);
     my $itr = Teng::Iterator->new(
@@ -585,6 +589,10 @@ sub search_by_sql {
 
 sub single_by_sql {
     my ($self, $sql, $bind, $table_name) = @_;
+
+    if ($table_name && $sql !~ /$table_name/i) {
+        warn "'$table_name' is not appeared in sql: $sql";
+    }
 
     $table_name ||= $self->_guess_table_name( $sql );
     my $table = $self->{schema}->get_table( $table_name );

--- a/t/002_common/008_search_named.t
+++ b/t/002_common/008_search_named.t
@@ -1,6 +1,7 @@
 use t::Utils;
 use Mock::Basic;
 use Test::More;
+use Test::Warn;
 
 my $dbh = t::Utils->setup_dbh;
 my $db = Mock::Basic->new({dbh => $dbh});
@@ -82,6 +83,10 @@ subtest 'search_named with non existent bind' => sub {
         );
     };
     like $@, qr/'name' does not exist in bind hash/;
+};
+
+subtest 'search_named table name 404' => sub {
+    warning_like { my $itr = $db->search_named(q{SELECT * FROM mock_basic WHERE id = :id}, {id => 1}, 'foobar'); } qr/'foobar' is not appeared in sql:/;
 };
 
 done_testing;

--- a/t/002_common/009_search_by_sql.t
+++ b/t/002_common/009_search_by_sql.t
@@ -1,6 +1,7 @@
 use t::Utils;
 use Mock::Basic;
 use Test::More;
+use Test::Warn;
 
 my $dbh = t::Utils->setup_dbh;
 my $db = Mock::Basic->new({dbh => $dbh});
@@ -18,6 +19,10 @@ subtest 'search_by_sql' => sub {
     isa_ok $row, 'Teng::Row';
     is $row->id , 1;
     is $row->name, 'perl';
+};
+
+subtest 'search_by_sql table name 404' => sub {
+    warning_like { my $itr = $db->search_by_sql(q{SELECT * FROM mock_basic WHERE id = ?}, [1], 'foobar') } qr/'foobar' is not appeared in sql:/;
 };
 
 done_testing;


### PR DESCRIPTION
Currently Teng allows following with no warnings:

```
my $row = $teng->search_by_sql('SELECT * FROM entry WHERE id = ?', [1], 'user');
$row->delete; # user with id = 1 will be deleted.
```

This patch appends warning when the table name is not exists in the sql.

Or more solution with consideration:
- No warning option?
- Just die in these cases?
