### PR TITLE
Fix POD for APIs of Teng::Schema::Table

### DIFF
--- a/lib/Teng/Schema/Table.pm
+++ b/lib/Teng/Schema/Table.pm
@@ -139,13 +139,13 @@ create new Teng::Schema::Table's object.
 
 get column SQL type.
 
-=item $table->set_deflator
+=item $table->add_deflator($column_rule, $code)
 
-set deflate code reference.
+add deflate code reference.
 
-=item $table->set_inflator
+=item $table->add_inflator($column_rule, $code)
 
-set inflate code reference.
+add inflate code reference.
 
 =item $table->call_deflate
 


### PR DESCRIPTION
Fix POD in `Teng::Schema::Table`, to fit to implementation (changed on badd7dd7a6b06c47c7393d0b542bab6a4df9b6e8):
- `#get_inflator()` and `#get_deflator()` are absent.
- `#set_inflator()` (and that for deflator) are not implemented.  Instead, `#add_inflator()` and `#add_deflator()` are defined.
