### PR TITLE
skip fork tests on win32 (handles can't be shared between threads)

### DIFF
--- a/t/001_basic/026_fork.t
+++ b/t/001_basic/026_fork.t
@@ -3,6 +3,8 @@ use Test::More;
 use Mock::Basic;
 use Test::SharedFork;
 
+plan skip_all => 'not for Win32' if $^O eq 'MSWin32';
+
 my $dbh = t::Utils->setup_dbh;
 my $db = Mock::Basic->new({dbh => $dbh});
 $db->setup_test_db;

--- a/t/001_basic/027_fork_self_reconnect.t
+++ b/t/001_basic/027_fork_self_reconnect.t
@@ -3,6 +3,8 @@ use Test::More;
 use Mock::Basic;
 use Test::SharedFork;
 
+plan skip_all => 'not for Win32' if $^O eq 'MSWin32';
+
 unlink './t/main.db' if -f './t/main.db';
 my $db = Mock::Basic->new(
     {

--- a/t/001_basic/028_fork_self_reconnect_dbh.t
+++ b/t/001_basic/028_fork_self_reconnect_dbh.t
@@ -3,6 +3,8 @@ use Test::More;
 use Mock::Basic;
 use Test::SharedFork;
 
+plan skip_all => 'not for Win32' if $^O eq 'MSWin32';
+
 my $dbh = t::Utils->setup_dbh('./t/main.db');
 my $db = Mock::Basic->new({dbh => $dbh});
 $db->setup_test_db;


### PR DESCRIPTION
Win32ではfork()した先で既存のdbhを使うと上記のエラーが出てしまうので、forkがらみのテストはスキップするようにしておきました。

cf: http://www.cpantesters.org/distro/T/Teng.html#Teng-0.21?grade=1&perlmat=2&patches=2&oncpan=2&distmat=2&perlver=ALL&osname=mswin32&version=0.21
