### PR TITLE
Teng::Schema::Declare#name : set $row_class only if it doesn't exist.

### DIFF
--- a/lib/Teng/Schema/Declare.pm
+++ b/lib/Teng/Schema/Declare.pm
@@ -91,7 +91,7 @@ sub table(&) {
     no warnings 'once';
     local *{"$dest_class\::name"}      = sub ($) { 
         $table_name = shift;
-        $row_class  = row_namespace($table_name);
+        $row_class  ||= row_namespace($table_name);
     };
     local *{"$dest_class\::pk"}        = sub (@) { @table_pk = @_ };
     local *{"$dest_class\::columns"}   = sub (@) { @table_columns = @_ };

--- a/t/001_basic/015_row_class.t
+++ b/t/001_basic/015_row_class.t
@@ -38,6 +38,20 @@ use Test::More;
         row_class 'Mock::BasicRow::FooRow';
     };
 
+    table {
+        row_class 'Mock::BasicRow::BarRow';
+        name 'mock_basic_row_bar';
+        pk 'id';
+        columns qw/
+            id
+            name
+        /;
+    };
+    package Mock::BasicRow::BarRow;
+    use strict;
+    use warnings;
+    use base 'Teng::Row';
+
     package Mock::BasicRow::FooRow;
     use strict;
     use warnings;
@@ -85,6 +99,7 @@ subtest 'your row class' => sub {
 
 subtest 'row_class specific Schema.pm' => sub {
     is +$db_basic_row->schema->get_row_class('mock_basic_row_foo'), 'Mock::BasicRow::FooRow';
+    is +$db_basic_row->schema->get_row_class('mock_basic_row_bar'), 'Mock::BasicRow::BarRow';
 };
 
 subtest 'handle' => sub {


### PR DESCRIPTION
When calling table() with T::S::D, if row_class() is called before name(), setting the row class name will be ignored.

This change should make the two subs work correctly together.
