### PR TITLE
Allow to use an alternate transaction manager class.

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -453,7 +453,9 @@ sub delete {
 sub txn_manager  {
     my $self = shift;
     $self->_verify_pid;
-    $self->{txn_manager} ||= DBIx::TransactionManager->new($self->dbh);
+    $self->{txn_manager} ||= ($self->{txn_manager_class})
+        ? $self->{txn_manager_class}->new($self->dbh)
+        : DBIx::TransactionManager->new($self->dbh);
 }
 
 sub in_transaction_check {


### PR DESCRIPTION
First of all, I'd like to say that DBIx::TransactionManager performs wonderfully under normal workloads. However, while working on a project at $work, we hit a problem where DBIx::TM would not commit a "main" transaction because we had to rollback an "inner" transaction.

I've been working on an alternate transaction manager (soon to be released either as part of DBIx::TM if nekokak-さん agrees or in its own distribution) that handle nested transactions through savepoints and I would like to be able to use it with Teng.

Right now my choices are :
- apply a local patch everytime I deploy/update Teng,
- monkey-patch Teng::txn_manager(), or...
- submit a PR ;)

I have mixed feelings about documenting this feature. On the one hand it might be interesting for people to know about it, on the other hand it would expose 1) Teng's internals and 2) DBIx::TransactionManager's API to the users. I will gladly amend my patch to add documentation if you think it is necessary.

Thank you for considering this patch.
