### PR TITLE
Add a sentence about return value of T::P::Lookup#lookup to doc

### DIFF
--- a/lib/Teng/Plugin/Lookup.pm
+++ b/lib/Teng/Plugin/Lookup.pm
@@ -82,5 +82,7 @@ lookup single row records.
 
 Teng#single is heavy.
 
+NOTE: Unlike Teng#single, this method returns a blank list in list context when no desired records are found.
+
 =back
 


### PR DESCRIPTION
The lookup method returns a blank list in list context when no desired records are found.
Sometimes it makes people confused because they are expecting that the behavior of lookup() is totally equivalent to the single() method, so I suggest you to add a sentence about this difference to the POD.
