### PR TITLE
Add `Teng::Schema::Declare#row_class_prefix`

### DIFF
--- a/lib/Teng/Schema/Declare.pm
+++ b/lib/Teng/Schema/Declare.pm
@@ -15,7 +15,7 @@ our @EXPORT = qw(
     base_row_class
     inflate
     deflate
-    row_class_prefix
+    default_row_class_prefix
 );
 our $CURRENT_SCHEMA_CLASS;
 
@@ -31,14 +31,14 @@ sub base_row_class($) {
     $current->{__base_row_class} = $_[0];
 }
 
-sub row_class_prefix ($) {
-    _current_schema()->{__row_class_prefix} = $_[0];
+sub default_row_class_prefix ($) {
+    _current_schema()->{__default_row_class_prefix} = $_[0];
 }
 
 sub row_namespace ($) {
     my $table_name = shift;
 
-    my $prefix = defined(_current_schema()->{__row_class_prefix}) ? _current_schema()->{__row_class_prefix} : do {
+    my $prefix = defined(_current_schema()->{__default_row_class_prefix}) ? _current_schema()->{__default_row_class_prefix} : do {
         (my $caller = caller(1)) =~ s/::Schema$//;
         join '::', $caller, 'Row';
     };
@@ -223,9 +223,9 @@ Default value is L<Teng::Row>.
 
 This option is useful when you adds features for My::DB::Row class.
 
-=item C<row_class_prefix>
+=item C<default_row_class_prefix>
 
-Specify the prefix of row class.
+Specify the default prefix of row class.
 
 Default value is determined by the schema class.
 

--- a/lib/Teng/Schema/Declare.pm
+++ b/lib/Teng/Schema/Declare.pm
@@ -15,6 +15,7 @@ our @EXPORT = qw(
     base_row_class
     inflate
     deflate
+    row_class_prefix
 );
 our $CURRENT_SCHEMA_CLASS;
 
@@ -30,11 +31,18 @@ sub base_row_class($) {
     $current->{__base_row_class} = $_[0];
 }
 
+sub row_class_prefix ($) {
+    _current_schema()->{__row_class_prefix} = $_[0];
+}
+
 sub row_namespace ($) {
     my $table_name = shift;
 
-    (my $caller = caller(1)) =~ s/::Schema$//;
-    join '::', $caller, 'Row', Teng::Schema::camelize($table_name);
+    my $prefix = defined(_current_schema()->{__row_class_prefix}) ? _current_schema()->{__row_class_prefix} : do {
+        (my $caller = caller(1)) =~ s/::Schema$//;
+        join '::', $caller, 'Row';
+    };
+    join '::', $prefix, Teng::Schema::camelize($table_name);
 }
 
 sub _current_schema {
@@ -214,6 +222,24 @@ Specify the default base row class with Teng::Schema::Declare.
 Default value is L<Teng::Row>.
 
 This option is useful when you adds features for My::DB::Row class.
+
+=item C<row_class_prefix>
+
+Specify the prefix of row class.
+
+Default value is determined by the schema class.
+
+e.g.:
+
+    package My::DB::Schema;
+    use Teng::Schema::Declare;
+    table {
+        name 'user';
+        column qw(name);
+    };
+
+    __PACKAGE__->instance->get_row_class('user'); # => My::DB::Row::User
+    1;
 
 =back
 

--- a/lib/Teng/Schema/Declare.pm
+++ b/lib/Teng/Schema/Declare.pm
@@ -227,6 +227,19 @@ This option is useful when you adds features for My::DB::Row class.
 
 Specify the default prefix of row class.
 
+C<row_class> of each table definition has priority over C<default_row_class_prefix>.
+
+e.g.:
+    use Teng::Schema::Declare;
+    my $schema = schema {
+        default_row_class_prefix 'My::Entity';
+        table {
+            name 'user';
+            column qw(name);
+        };
+    };
+    $schema->get_row_class('user'); # => My::Entity::User
+
 Default value is determined by the schema class.
 
 e.g.:

--- a/t/001_basic/017_row_class_prefix.t
+++ b/t/001_basic/017_row_class_prefix.t
@@ -13,6 +13,18 @@ subtest 'with prefix' => sub {
     is($schema->get_row_class('body'), 'My::Entity::Body');
 };
 
+subtest 'with prefix and row_class' => sub {
+    my $schema = schema {
+        default_row_class_prefix 'My::DefaultRow';
+        table {
+            name 'default_row';
+            columns qw(id);
+            row_class 'My::Row';
+        };
+    };
+    is($schema->get_row_class('default_row'), 'My::Row'), 'row_class has priority';
+};
+
 subtest 'without prefix' => sub {
     {
         package t::My::DB::Schema;

--- a/t/001_basic/017_row_class_prefix.t
+++ b/t/001_basic/017_row_class_prefix.t
@@ -1,0 +1,29 @@
+use t::Utils;
+use Test::More;
+use Teng::Schema::Declare;
+
+subtest 'with prefix' => sub {
+    my $schema = schema {
+        row_class_prefix 'My::Entity';
+        table {
+            name 'body';
+            columns qw(id);
+        };
+    };
+    is($schema->get_row_class('body'), 'My::Entity::Body');
+};
+
+subtest 'without prefix' => sub {
+    {
+        package t::My::DB::Schema;
+        use Teng::Schema::Declare;
+        table {
+            name 'user';
+            columns qw(name);
+        };
+    };
+    my $schema = t::My::DB::Schema->instance;
+    is($schema->get_row_class('user'), 't::My::DB::Row::User');
+};
+
+done_testing;

--- a/t/001_basic/017_row_class_prefix.t
+++ b/t/001_basic/017_row_class_prefix.t
@@ -4,7 +4,7 @@ use Teng::Schema::Declare;
 
 subtest 'with prefix' => sub {
     my $schema = schema {
-        row_class_prefix 'My::Entity';
+        default_row_class_prefix 'My::Entity';
         table {
             name 'body';
             columns qw(id);


### PR DESCRIPTION
Once we specified `row_class_prefix`, each table definition has a row class name with common prefix.

It is comfortable for automation such as [SQL::Translator::Producer::Teng](https://github.com/Songmu/p5-SQL-Translator-Producer-Teng)