### PR TITLE
make cpan testers happy on win32

### DIFF
--- a/t/002_common/024_txn_scope.t
+++ b/t/002_common/024_txn_scope.t
@@ -38,7 +38,7 @@ subtest 'insert using txn_scope (and let the guard fire)' => sub {
         is $row->name, 'perl';
     }
 
-    like $warning, qr{Guard created at \.?\/?t/002_common/024_txn_scope\.t line 32};
+    like $warning, qr{\QGuard created at $0 line 32};
 };
 
 done_testing;


### PR DESCRIPTION
Teng is win32 compatible, it is the failing test that breaks the things.

The reason it fails is win32 paths look like "path\to\directory" while "path/to/directory" was expected, note that separators differ.

So the simple fix comes out: just use $0, quotemeta() is required.
