### PR TITLE
insert/fast_insert for MySQL 5.7

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -346,7 +346,12 @@ sub do_insert {
 sub fast_insert {
     my ($self, $table_name, $args, $prefix) = @_;
 
-    $self->do_insert($table_name, $args, $prefix);
+    my $sth = $self->do_insert($table_name, $args, $prefix);
+
+    # XXX in MySQL 5.7.8 or later, $self->dbh->{mysql_insertid} will always return 0,
+    # so that get mysql_insertid from $sth. (https://bugs.mysql.com/bug.php?id=78778)
+    return $sth->{mysql_insertid} if defined $sth->{mysql_insertid};
+
     # XXX in Pg, _last_insert_id has potential failure when inserting to non Serial table or explicitly inserting Serrial id
     $self->_last_insert_id($table_name);
 }
@@ -354,7 +359,7 @@ sub fast_insert {
 sub insert {
     my ($self, $table_name, $args, $prefix) = @_;
 
-    $self->do_insert($table_name, $args, $prefix);
+    my $sth = $self->do_insert($table_name, $args, $prefix);
     return unless defined wantarray;
 
     my $table = $self->schema->get_table($table_name);
@@ -362,7 +367,10 @@ sub insert {
 
     my @missing_primary_keys = grep { not defined $args->{$_} } @$pk;
     if (@missing_primary_keys == 1) {
-        $args->{$missing_primary_keys[0]} = $self->_last_insert_id($table_name, $missing_primary_keys[0]);
+        # XXX in MySQL 5.7.8 or later, $self->dbh->{mysql_insertid} will always return 0,
+        # so that get mysql_insertid from $sth. (https://bugs.mysql.com/bug.php?id=78778)
+        $args->{$missing_primary_keys[0]} = defined $sth->{mysql_insertid} ? $sth->{mysql_insertid}
+                                          : $self->_last_insert_id($table_name, $missing_primary_keys[0]);
     }
 
     return $args if $self->suppress_row_objects;

--- a/t/002_common/001_insert.t
+++ b/t/002_common/001_insert.t
@@ -1,6 +1,7 @@
 use t::Utils;
 use Mock::Basic;
 use Test::More;
+use Test::Mock::Guard qw/mock_guard/;
 
 my $dbh = t::Utils->setup_dbh;
 my $db = Mock::Basic->new({dbh => $dbh});
@@ -67,6 +68,25 @@ subtest 'fast_insert with pkey not named "id"' => sub {
         name => 'perl',
     });
     is $last_insert_id, 2;
+};
+
+subtest 'insert returning row for mysql_insertid when sth has mysql_insertid' => sub {
+    $db->fast_insert('mock_basic',{
+        id   => 999,
+        name => 'python',
+    });
+
+    my $guard = mock_guard('Teng' => {
+        do_insert => { mysql_insertid => 999 },
+    });
+
+    my $row = $db->insert('mock_basic',{
+        name => 'python',
+    });
+
+    isa_ok $row, 'HASH';
+    is $row->{id}, 999;
+    is $row->{name}, 'python';
 };
 
 done_testing;

--- a/t/002_common/030_fast_insert.t
+++ b/t/002_common/030_fast_insert.t
@@ -4,6 +4,7 @@ use utf8;
 use Test::More;
 use t::Utils;
 use Mock::Basic;
+use Test::Mock::Guard qw/mock_guard/;
 
 my $dbh = t::Utils->setup_dbh;
 my $db = Mock::Basic->new({dbh => $dbh});
@@ -20,6 +21,17 @@ subtest 'fast_insert returning last_insert_id' => sub {
         name => 'ruby',
     });
     is $id2, 2;
+};
+
+subtest 'fast_insert returning mysql_insertid when sth has mysql_insertid' => sub {
+    my $guard = mock_guard('Teng' => {
+        do_insert => { mysql_insertid => 3 },
+    });
+
+    my $id = $db->fast_insert('mock_basic',{
+        name => 'ruby',
+    });
+    is $id, 3;
 };
 
 done_testing;


### PR DESCRIPTION
In MySQL 5.7.8 or later, `dbh->{mysql_insertid}` will return 0, so that `fast_insert` will return 0 and `insert` will return undef.
To fix this problem, I modified to get `mysql_insertid` from`sth` instead of `dbh`.
This is a workaround...

reference: https://bugs.mysql.com/bug.php?id=78778
