### PR TITLE
Update testing Perl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
+sudo: false
 language: perl
 perl:
+  - "5.22"
   - "5.20"
   - "5.18"
   - "5.16"
   - "5.14"
   - "5.12"
   - "5.10"
-  - "5.8"
 install:
   cpanm --quiet --installdeps --notest --with-develop .


### PR DESCRIPTION
- Some dependencies no longer work on Perl 5.8
- Add Perl 5.22
- Set `sudo: false` for fast testing

See
- https://travis-ci.org/nekokak/p5-Teng/jobs/143044475