### PR TITLE
When the return value is never used, should not create row/iterator object

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -288,6 +288,12 @@ sub execute {
         $self->handle_error($sql, $binds, $@);
     }
 
+    # When the return value is never used, should finish statement handler
+    unless (defined wantarray) {
+        $sth->finish();
+        return;
+    }
+
     return $sth;
 }
 

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -583,6 +583,14 @@ sub single {
         $opt
     );
     my $sth = $self->execute($sql, \@binds);
+
+    # When the return value is never used, should not create row object
+    # case example: use `FOR UPDATE` query for global locking
+    unless (defined wantarray) {
+        $sth->finish();
+        return;
+    }
+
     my $row = $sth->fetchrow_hashref($self->{fields_case});
 
     return undef unless $row; ## no critic
@@ -604,6 +612,14 @@ sub search_by_sql {
 
     $table_name ||= $self->_guess_table_name( $sql );
     my $sth = $self->execute($sql, $bind);
+
+    # When the return value is never used, should not create iterator object
+    # case example: use `FOR UPDATE` query for global locking
+    unless (defined wantarray) {
+        $sth->finish();
+        return;
+    }
+
     my $itr = Teng::Iterator->new(
         teng             => $self,
         sth              => $sth,
@@ -624,6 +640,14 @@ sub single_by_sql {
     Carp::croak("No such table $table_name") unless $table;
 
     my $sth = $self->execute($sql, $bind);
+
+    # When the return value is never used, should not create row object
+    # case example: use `FOR UPDATE` query for global locking
+    unless (defined wantarray) {
+        $sth->finish();
+        return;
+    }
+
     my $row = $sth->fetchrow_hashref($self->{fields_case});
 
     return unless $row;


### PR DESCRIPTION
case example: use `FOR UPDATE` query for global locking.

``` perl
my $txn = $db->txn_scope();
$db->single(my_keyed_mutex => {
    key => 1,
});

...

$txn->commit;
```
