### PR TITLE
add apply_sql_types & guess_sql_types method

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'DBIx::TransactionManager', '1.06';
 requires 'Data::Page';
 requires 'Data::Page::NoTotalEntries', '0.02';
 requires 'SQL::Maker', '0.14';
+requires 'Scalar::Util';
 requires 'parent';
 
 on configure => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -20,6 +20,7 @@ on test => sub {
     requires 'Test::More', '0.96';
     requires 'Test::Requires';
     requires 'Test::SharedFork', '0.15';
+    requires 'JSON::XS';
 };
 
 on develop => sub {

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -23,6 +23,8 @@ use Class::Accessor::Lite 0.05
         owner_pid
         no_ping
         fields_case
+        apply_sql_types
+        guess_sql_types
     )]
 ;
 
@@ -63,6 +65,7 @@ sub new {
         owner_pid    => $$,
         no_ping      => 0,
         fields_case  => 'NAME_lc',
+        boolean_type => {true => 1, false => 0},
         %args,
     }, $class;
 
@@ -88,6 +91,15 @@ sub new {
     }
 
     return $self;
+}
+
+sub set_boolean_type {
+    my $self = shift;
+    if (@_) {
+        my ($true, $false) = @_;
+        $self->{boolean_type} = {true => $true, false => $false};
+    }
+    return $self->{boolean_type};
 }
 
 sub mode {
@@ -611,6 +623,8 @@ sub search_by_sql {
         row_class        => $self->{schema}->get_row_class($table_name),
         table            => $self->{schema}->get_table( $table_name ),
         table_name       => $table_name,
+        apply_sql_types  => $self->{apply_sql_types} || $self->{guess_sql_types},
+        guess_sql_types  => $self->{guess_sql_types},
         suppress_object_creation => $self->{suppress_row_objects},
     );
     return wantarray ? $itr->all : $itr;
@@ -1153,6 +1167,26 @@ Disconnects from the currently connected database.
 =item C<$teng-E<gt>suppress_row_objects($flag)>
 
 set row object creation mode.
+
+=item C<$teng-E<gt>apply_sql_types($flag)>
+
+set sql type application mode.
+
+see apply_sql_types in L<Teng::Iterator/METHODS>
+
+=item C<$teng-E<gt>guess_sql_types($flag)>
+
+set sql type guessing mode.
+this implies apply_sql_type true.
+
+see guess_sql_types in L<Teng::Iterator/METHODS>
+
+=item C<$teng-E<gt>set_boolean_type($true, $false)>
+
+set scalar to correspond boolean.
+this is ignored when aply_sql_type is not true.
+
+  $teng->set_boolean_type(JSON::XS::true, JSON::XS::false);
 
 =item C<$teng-E<gt>load_plugin();>
 

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -1170,13 +1170,13 @@ set row object creation mode.
 
 =item C<$teng-E<gt>apply_sql_types($flag)>
 
-set sql type application mode.
+set SQL type application mode.
 
 see apply_sql_types in L<Teng::Iterator/METHODS>
 
 =item C<$teng-E<gt>guess_sql_types($flag)>
 
-set sql type guessing mode.
+set SQL type guessing mode.
 this implies apply_sql_type true.
 
 see guess_sql_types in L<Teng::Iterator/METHODS>

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -65,7 +65,7 @@ sub new {
         owner_pid    => $$,
         no_ping      => 0,
         fields_case  => 'NAME_lc',
-        boolean_type => {true => 1, false => 0},
+        boolean_value => {true => 1, false => 0},
         %args,
     }, $class;
 
@@ -93,13 +93,13 @@ sub new {
     return $self;
 }
 
-sub set_boolean_type {
+sub set_boolean_value {
     my $self = shift;
     if (@_) {
         my ($true, $false) = @_;
-        $self->{boolean_type} = {true => $true, false => $false};
+        $self->{boolean_value} = {true => $true, false => $false};
     }
-    return $self->{boolean_type};
+    return $self->{boolean_value};
 }
 
 sub mode {
@@ -1181,12 +1181,12 @@ this implies apply_sql_type true.
 
 see guess_sql_types in L<Teng::Iterator/METHODS>
 
-=item C<$teng-E<gt>set_boolean_type($true, $false)>
+=item C<$teng-E<gt>set_boolean_value($true, $false)>
 
 set scalar to correspond boolean.
 this is ignored when aply_sql_type is not true.
 
-  $teng->set_boolean_type(JSON::XS::true, JSON::XS::false);
+  $teng->set_boolean_value(JSON::XS::true, JSON::XS::false);
 
 =item C<$teng-E<gt>load_plugin();>
 

--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -1177,14 +1177,14 @@ see apply_sql_types in L<Teng::Iterator/METHODS>
 =item C<$teng-E<gt>guess_sql_types($flag)>
 
 set SQL type guessing mode.
-this implies apply_sql_type true.
+this implies apply_sql_types true.
 
 see guess_sql_types in L<Teng::Iterator/METHODS>
 
 =item C<$teng-E<gt>set_boolean_value($true, $false)>
 
 set scalar to correspond boolean.
-this is ignored when aply_sql_type is not true.
+this is ignored when apply_sql_types is not true.
 
   $teng->set_boolean_value(JSON::XS::true, JSON::XS::false);
 

--- a/lib/Teng/Iterator.pm
+++ b/lib/Teng/Iterator.pm
@@ -164,15 +164,15 @@ Set row object creation mode.
 
 Set column type application mode.
 
-If column has sql type and it is numeric, regard it as number and add 0 to the value.
-If column has sql type and it isn't numeric, regart it as string and add '' to the value.
-If column doesn't have sql type, the value won't be changed.
+If column has SQL type and it is numeric, regard it as number and add 0 to the value.
+If column has SQL type and it isn't numeric, regard it as string and add '' to the value.
+If column doesn't have SQL type, the value won't be changed.
 
 =item $itr->guess_sql_types($bool)
 
 If this is true, this implies apply_sql_types also true.
-If column has no sql type, it guesses sql type with its value.
-When column value likes numeric, regart it as number and add 0 to the value.
+If column has no SQL type, it guesses SQL type with its value.
+When column value likes numeric, regard it as number and add 0 to the value.
 If not, regard it as string and add '' to the value.
 
 =back

--- a/lib/Teng/Iterator.pm
+++ b/lib/Teng/Iterator.pm
@@ -2,6 +2,7 @@ package Teng::Iterator;
 use strict;
 use warnings;
 use Carp ();
+use Scalar::Util qw/looks_like_number/;
 use Class::Accessor::Lite (
     rw => [qw/suppress_object_creation apply_sql_types guess_sql_types/],
 );
@@ -78,7 +79,7 @@ sub _apply_sql_types {
                 $row->{$column} .= '';
             }
         } elsif ($self->{guess_sql_types}) {
-            if ($row->{$column} =~ m{^\d+(?:\.\d+)?$}) {
+            if (looks_like_number($row->{$column})) {
                 $row->{$column} += 0;
             } else {
                 $row->{$column} .= '';
@@ -164,7 +165,7 @@ Set row object creation mode.
 Set column type application mode.
 
 If column has sql type and it is numeric, regard it as number and add 0 to the value.
-If column has sql type and it isn't numeric, regart it as string adn add '' to the value.
+If column has sql type and it isn't numeric, regart it as string and add '' to the value.
 If column doesn't have sql type, the value won't be changed.
 
 =item $itr->guess_sql_types($bool)

--- a/lib/Teng/Iterator.pm
+++ b/lib/Teng/Iterator.pm
@@ -66,11 +66,11 @@ sub _apply_sql_types {
                ) {
                 $row->{$column} += 0;
             } elsif ($type == SQL_BOOLEAN) {
-                if ($self->{teng}->{boolean_type}) {
+                if ($self->{teng}->{boolean_value}) {
                     if ($row->{$column}) {
-                        $row->{$column} = $self->{teng}->{boolean_type}->{true};
+                        $row->{$column} = $self->{teng}->{boolean_value}->{true};
                     } else {
-                        $row->{$column} = $self->{teng}->{boolean_type}->{false};
+                        $row->{$column} = $self->{teng}->{boolean_value}->{false};
                     }
                 } else {
                     $row->{$column} += 0;

--- a/lib/Teng/Iterator.pm
+++ b/lib/Teng/Iterator.pm
@@ -3,8 +3,9 @@ use strict;
 use warnings;
 use Carp ();
 use Class::Accessor::Lite (
-    rw => [qw/suppress_object_creation/],
+    rw => [qw/suppress_object_creation apply_sql_types guess_sql_types/],
 );
+use DBI qw(:sql_types);
 
 sub new {
     my ($class, %args) = @_;
@@ -31,6 +32,7 @@ sub next {
     if ($self->{suppress_object_creation}) {
         return $row;
     } else {
+        $self->_apply_sql_types($row) if $self->{apply_sql_types};
         return $self->{row_class}->new(
             {
                 sql            => $self->{sql},
@@ -41,6 +43,47 @@ sub next {
                 select_columns => $self->{select_columns},
             }
         );
+    }
+}
+
+sub _apply_sql_types {
+    my ($self, $row) = @_;
+
+    foreach my $column (keys %$row) {
+        my $type = $self->{table}->{sql_types}->{$column};
+        if (defined $type) {
+            if (   $type == SQL_BIGINT
+                or $type == SQL_BIT
+                or $type == SQL_TINYINT
+                or $type == SQL_NUMERIC
+                or $type == SQL_INTEGER
+                or $type == SQL_SMALLINT
+                or $type == SQL_DECIMAL
+                or $type == SQL_FLOAT
+                or $type == SQL_REAL
+                or $type == SQL_DOUBLE
+               ) {
+                $row->{$column} += 0;
+            } elsif ($type == SQL_BOOLEAN) {
+                if ($self->{teng}->{boolean_type}) {
+                    if ($row->{$column}) {
+                        $row->{$column} = $self->{teng}->{boolean_type}->{true};
+                    } else {
+                        $row->{$column} = $self->{teng}->{boolean_type}->{false};
+                    }
+                } else {
+                    $row->{$column} += 0;
+                }
+            } else {
+                $row->{$column} .= '';
+            }
+        } elsif ($self->{guess_sql_types}) {
+            if ($row->{$column} =~ m{^\d+(?:\.\d+)?$}) {
+                $row->{$column} += 0;
+            } else {
+                $row->{$column} .= '';
+            }
+        }
     }
 }
 
@@ -115,6 +158,21 @@ Get all row data in array.
 =item $itr->suppress_object_creation($bool)
 
 Set row object creation mode.
+
+=item $itr->apply_sql_types($bool)
+
+Set column type application mode.
+
+If column has sql type and it is numeric, regard it as number and add 0 to the value.
+If column has sql type and it isn't numeric, regart it as string adn add '' to the value.
+If column doesn't have sql type, the value won't be changed.
+
+=item $itr->guess_sql_types($bool)
+
+If this is true, this implies apply_sql_types also true.
+If column has no sql type, it guesses sql type with its value.
+When column value likes numeric, regart it as number and add 0 to the value.
+If not, regard it as string and add '' to the value.
 
 =back
 

--- a/t/002_common/031_apply_sql_types.t
+++ b/t/002_common/031_apply_sql_types.t
@@ -1,0 +1,125 @@
+use t::Utils;
+use Mock::Basic;
+use Test::More;
+use JSON::XS;
+
+my $dbh = t::Utils->setup_dbh;
+my $db = Mock::Basic->new({dbh => $dbh});
+$db->setup_test_db;
+
+$db->insert('mock_basic_sql_types',{
+    id   => 1,
+    name => 'perl',
+    delete_fg => 1,
+});
+$db->insert('mock_basic_sql_types',{
+    id   => 2,
+    name => 'ruby',
+    delete_fg => 0,
+});
+$db->insert('mock_basic_sql_types',{
+    id   => 3,
+    name => 4,
+    delete_fg => 1,
+});
+
+sub isnum ($) {
+    return 0 if $_[0] eq '';
+    $_[0] ^ $_[0] ? 0 : 1
+}
+
+sub isbool {
+    my ($db, $bool) = @_;
+    if ($bool) {
+        $bool == $db->{boolean_type}->{true};
+    } else {
+        $bool == $db->{boolean_type}->{false};
+    }
+}
+
+subtest 'search_no_sql_types' => sub {
+    my $itr = $db->search('mock_basic_sql_types');
+    isa_ok $itr, 'Teng::Iterator';
+
+    my $driver_name = $db->dbh->{Driver}->{Name};
+    if ($driver_name ne 'mysql') {
+        while (my $row = $itr->next) {
+            isa_ok $row, 'Teng::Row';
+            is isnum($row->id), 1, "is num($driver_name)";
+            is isnum($row->name), 0, "is string($driver_name)";
+            is isnum($row->delete_fg), 1, "is num($driver_name)";
+        }
+    } else {
+        while (my $row = $itr->next) {
+            isa_ok $row, 'Teng::Row';
+            is isnum($row->id), 0, "is string";
+            is isnum($row->name), 0, "is string";
+            is isnum($row->delete_fg), 0, "is string";
+        }
+    }
+};
+
+subtest 'search_apply_sql_types_itr' => sub {
+    my $itr = $db->search('mock_basic_sql_types');
+    isa_ok $itr, 'Teng::Iterator';
+
+    $itr->apply_sql_types(1);
+    while (my $row = $itr->next) {
+        isa_ok $row, 'Teng::Row';
+        is isnum($row->id), 1, "is num";
+        is isnum($row->name), 0, "is string";
+        is isbool($db, $row->delete_fg), 1, "is bool";
+    }
+};
+
+subtest 'search_apply_sql_types_db' => sub {
+    $db->apply_sql_types(1);
+    my $itr = $db->search('mock_basic_sql_types');
+    isa_ok $itr, 'Teng::Iterator';
+
+    while (my $row = $itr->next) {
+        isa_ok $row, 'Teng::Row';
+        is isnum($row->id), 1, "is num";
+        is isnum($row->name), 0, "is string";
+        is isbool($db, $row->delete_fg), 1, "is bool";
+    }
+};
+
+subtest 'search_apply_sql_types_boolean' => sub {
+    $db->set_boolean_type(JSON::XS::true, JSON::XS::false);
+    my $itr = $db->search('mock_basic_sql_types');
+    isa_ok $itr, 'Teng::Iterator';
+
+    while (my $row = $itr->next) {
+        isa_ok $row, 'Teng::Row';
+        is isnum($row->id), 1, "is num";
+        is isnum($row->name), 0, "is string";
+        is isbool($db, $row->delete_fg), 1, "is bool";
+    }
+};
+
+subtest 'count' => sub {
+    my $itr = $db->search_by_sql('select count(*) as cnt from mock_basic_sql_types');
+    isa_ok $itr, 'Teng::Iterator';
+
+    my $row = $itr->next;
+    my $driver_name = $db->dbh->{Driver}->{Name};
+    if ($driver_name ne 'mysql') {
+        is isnum($row->cnt), 1, "is num($driver_name)";
+    } else {
+        is isnum($row->cnt), 0, 'is string';
+    }
+};
+
+subtest 'count_with_guess_sql_type' => sub {
+    $db->guess_sql_types(1);
+    my $itr = $db->search_by_sql('select count(*) as cnt from mock_basic_sql_types');
+    isa_ok $itr, 'Teng::Iterator';
+
+    my $row = $itr->next;
+    my $driver_name = $db->dbh->{Driver}->{Name};
+    is isnum($row->cnt), 1, 'is num';
+};
+
+
+done_testing;

--- a/t/002_common/031_apply_sql_types.t
+++ b/t/002_common/031_apply_sql_types.t
@@ -31,9 +31,9 @@ sub isnum ($) {
 sub isbool {
     my ($db, $bool) = @_;
     if ($bool) {
-        $bool == $db->{boolean_type}->{true};
+        $bool == $db->{boolean_value}->{true};
     } else {
-        $bool == $db->{boolean_type}->{false};
+        $bool == $db->{boolean_value}->{false};
     }
 }
 
@@ -86,7 +86,7 @@ subtest 'search_apply_sql_types_db' => sub {
 };
 
 subtest 'search_apply_sql_types_boolean' => sub {
-    $db->set_boolean_type(JSON::XS::true, JSON::XS::false);
+    $db->set_boolean_value(JSON::XS::true, JSON::XS::false);
     my $itr = $db->search('mock_basic_sql_types');
     isa_ok $itr, 'Teng::Iterator';
 

--- a/t/002_common/031_apply_sql_types.t
+++ b/t/002_common/031_apply_sql_types.t
@@ -95,6 +95,7 @@ subtest 'search_apply_sql_types_boolean' => sub {
         is isnum($row->id), 1, "is num";
         is isnum($row->name), 0, "is string";
         is isbool($db, $row->delete_fg), 1, "is bool";
+        like ref $row->delete_fg, qr{^JSON::.+Boolean}, "is JSON::* object";
     }
 };
 

--- a/t/lib/Mock/Basic.pm
+++ b/t/lib/Mock/Basic.pm
@@ -30,6 +30,14 @@ sub create_sqlite {
             primary key ( table_id )
         )
     });
+    $dbh->do(q{
+        CREATE TABLE mock_basic_sql_types (
+            id   integer,
+            name text,
+            delete_fg tinyint(1) default 0,
+            primary key ( id )
+        )
+    });
 }
 
 sub create_mysql {
@@ -61,6 +69,15 @@ sub create_mysql {
             PRIMARY KEY  (table_id)
         ) ENGINE=InnoDB
     });
+    $dbh->do( q{DROP TABLE IF EXISTS mock_basic_sql_types} );
+    $dbh->do(q{
+        CREATE TABLE mock_basic_sql_types (
+            id        INT auto_increment,
+            name      TEXT,
+            delete_fg TINYINT(1) default 0,
+            PRIMARY KEY  (id)
+        ) ENGINE=InnoDB
+    });
 }
 
 sub create_pg {
@@ -77,6 +94,14 @@ sub create_pg {
     $dbh->do(q{
         CREATE TABLE mock_basic_anotherpkey (
             table_id   SERIAL PRIMARY KEY,
+            name TEXT,
+            delete_fg boolean default false
+        )
+    });
+    $dbh->do( q{DROP TABLE IF EXISTS mock_basic_sql_types});
+    $dbh->do(q{
+        CREATE TABLE mock_basic_sql_types (
+            id   SERIAL PRIMARY KEY,
             name TEXT,
             delete_fg boolean default false
         )

--- a/t/lib/Mock/Basic/Schema.pm
+++ b/t/lib/Mock/Basic/Schema.pm
@@ -1,6 +1,7 @@
 package Mock::Basic::Schema;
 use utf8;
 use Teng::Schema::Declare;
+use DBI qw(:sql_types);
 
 table {
     name 'mock_basic';
@@ -30,6 +31,16 @@ table {
         name
         delete_fg
     /;
+};
+
+table {
+    name 'mock_basic_sql_types';
+    pk 'id';
+    columns(
+        {name => 'id'       , type => SQL_INTEGER},
+        {name => 'name'     , type => SQL_VARCHAR},
+        {name => 'delete_fg', type => SQL_BOOLEAN},
+    );
 };
 
 1;


### PR DESCRIPTION
DBD::msyqlが、数字のカラムを文字列として返してしまうという問題への対応になります(DBD::Pg, DBD::SQLiteは問題ないです)。
具体的なケースとしては、アプリにJSONで渡す時などに、id など数字で渡したいものが、文字列となってしまうというような問題への対応となります。

apply_sql_types というオプションを追加しています(TengとTeng::Iterator)。true であれば、スキーマ定義で type が定義されていれば、それを見て、数値のタイプであれば 0 を足して数字にします。それ以外であれば 空文字を追加して、文字列とするようにしています。
guess_sql_types は、正直微妙かとは思いますが、count(*)とかの定義できないタイプに対応するために、数字っぽければ数字とするようなものです。0始まりの値とか微妙なんですが、基本的には、ちゃんとtype定義している前提であれば、使えるかな...と思っています。

また、boolean用に true, false のオブジェクトを渡せるset_boolean_type も追加しています。