### PR TITLE
impl Teng::Plugnin::FindOrCreateBy

### DIFF
--- a/lib/Teng/Plugin/FindOrCreateBy.pm
+++ b/lib/Teng/Plugin/FindOrCreateBy.pm
@@ -1,0 +1,54 @@
+package Teng::Plugin::FindOrCreateBy;
+use strict;
+use warnings;
+use utf8;
+
+our @EXPORT = qw/find_or_create_by/;
+
+sub find_or_create_by {
+    my ($self, $table, $args, $cb) = @_;
+    my $row = $self->single($table, $args);
+    return $row if $row;
+    $args = $cb->($args) if ref $cb eq 'CODE';
+    $self->insert($table, $args)->refetch;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Teng::Plugin::FindOrCreateBy - provide find_or_create_by method for your Teng class.
+
+=head1 NAME
+
+    package MyDB;
+    use parent qw/Teng/;
+    __PACKAGE__->load_plugin('FindOrCreateBy');
+
+    package main;
+    my $db = MyDB->new(...);
+    my $row = $db->find_or_create_by('user',{name => 'lestrrat'}, sub {
+        my $user = shift;
+        $user->{age} = 20;
+        return $user;
+    });
+
+=head1 DESCRIPTION
+
+This plugin provides find_or_create_by method.
+
+=head1 METHODS
+
+=over 4
+
+=item $row = $db->find_or_create_by($table[, \%args, \&cb]])
+
+I<$table> table name for counting
+
+I<\%args> : HashRef for row data.
+
+|<\&cb> : Callback function to modify row data for creating
+
+=back

--- a/t/002_common/032_find_or_create_by.t
+++ b/t/002_common/032_find_or_create_by.t
@@ -1,0 +1,55 @@
+use t::Utils;
+use Mock::Basic;
+use Test::More;
+
+my $dbh = t::Utils->setup_dbh;
+my $db = Mock::Basic->new({dbh => $dbh});
+$db->setup_test_db;
+
+Mock::Basic->load_plugin('FindOrCreateBy');
+can_ok 'Mock::Basic' => 'find_or_create_by';
+
+subtest 'find_or_create_by' => sub {
+    my $mock_basic = $db->find_or_create_by('mock_basic',{
+        id   => 1,
+        name => 'perl',
+    }, sub {
+        my $row = shift;
+        $row->{delete_fg} = 1;
+        return $row;
+    });
+    is $mock_basic->name, 'perl';
+    is $mock_basic->delete_fg, 1, 'function should call';
+
+    $mock_basic = $db->find_or_create_by('mock_basic',{
+        id   => 1,
+        name => 'perl',
+    }, sub {
+        my $row = shift;
+        $row->{delete_fg} = 0;
+        return $row;
+    });
+    is $mock_basic->name, 'perl';
+    is $mock_basic->delete_fg, 1, 'function should not call';
+
+    is +$db->count('mock_basic', 'id',{name => 'perl'}), 1;
+};
+
+subtest 'find_or_create_by' => sub {
+    $db->delete('mock_basic');
+    local $SIG{__WARN__} = sub{};
+    eval {
+        $db->find_or_create_by('mock_basic',{
+            id   => 3,
+            name => \' = "ruby"',
+        }, sub {
+            my $row = shift;
+            $row->{delete_fg} = 0;
+            return $row;
+        });
+    };
+    ok $@;
+};
+
+done_testing;
+


### PR DESCRIPTION
Rails 4 で追加された find_or_create_by が欲しかったので Plugin として追加しました。

```sql
CREATE TABLE users (
  id SERIAL PRIMARY KEY,
  username TEXT UNIQUE,
  lastname TEXT NOT NULL
);
```

このようなテーブルがあります。

username というユニークキーで存在をチェックしつつ、存在しなければ他に必要なデータを与えつつ行を作りたいというケースを考えます。

users テーブルに `seagirl` を username カラムに持つ行は存在しない状態とします。
この時、下記のコードは lastname カラムの NOT NULL 制約に引っかかってエラーとなります。

```pl
my $row = $db->find_or_create('users', { username => 'seagirl' });
$row->update({ lastname => '吉津' });
```

このような場合、通常は下記のように single と insert に分けて記述する必要があります。

```pl
my $row = $db->single('users', { username => 'seagirl' });
unless ($row) {
  $db->insert({ username => 'seagirl', lastname => '吉津' });
}
```

このケースで find_or_create_by があれば、下記のような記述が可能です。

```pl
my $row = $db->find_or_create_by('users', { username => 'seagirl' }, sub {
  my $data = shift;
  $data->{lastname} = '吉津';
  return $data;
});
```

ご検討よろしくお願いします。

