### PR TITLE
Fix column name regression

### DIFF
--- a/lib/Teng.pm
+++ b/lib/Teng.pm
@@ -923,6 +923,11 @@ Specifies the row object creation mode. By default this value is C<false>.
 If you specifies this to a C<true> value, no row object will be created when
 a C<SELECT> statement is issued..
 
+=item * C<force_deflate_set_column>
+
+Specifies C<set_column>, C<set_columns> and column name method behaviour. By default this value is C<false>.
+If you specifies this to a C<true> value, C<set_column> or column name method will deflate argument.
+
 =item * C<sql_builder>
 
 Speficies the SQL builder object. By default SQL::Maker is used, and as such,

--- a/lib/Teng/Row.pm
+++ b/lib/Teng/Row.pm
@@ -62,7 +62,7 @@ sub get {
 
 sub set {
     my ($self, $col, $val) = @_;
-    $self->set_column( $col => $self->{table}->call_deflate($col, $val) ); 
+    $self->set_column( $col => $val, deflate => 1);
     delete $self->{_get_column_cached}->{$col};
     return $self;
 }
@@ -96,7 +96,10 @@ sub get_columns {
 }
 
 sub set_column {
-    my ($self, $col, $val) = @_;
+    my ($self, $col, $val, %opts) = @_;
+    if ($opts{deflate} || $self->handle->{force_deflate_set_column}) {
+        $val = $self->{table}->call_deflate($col, $val);
+    }
 
     if ( defined $self->{row_data}->{$col} 
       && defined $val 

--- a/t/001_basic/011_inflate.t
+++ b/t/001_basic/011_inflate.t
@@ -126,6 +126,8 @@ subtest 'insert/update on non existent table' => sub {
 };
 
 subtest 'update column name' => sub {
+    local $db->{force_deflate_set_column} = 1;
+
     # set method
     {
         my $row = $db->single('mock_inflate',{id => 1});
@@ -150,10 +152,25 @@ subtest 'update column name' => sub {
     }
     {
         my $row = $db->single('mock_inflate',{id => 1});
-        use Data::Dumper;
-        warn Dumper $row->hash ;
         is ref($row->hash), 'HASH';
         is $row->hash->{x}, 'foo';
+    }
+
+    # column name (update by same object)
+    {
+        my $row = $db->single('mock_inflate',{id => 1});
+        $row->hash({ x => 'foo' });
+        $row->update;
+        is ref($row->hash), 'HASH';
+        is $row->hash->{x}, 'foo';
+    }
+    {
+        my $row = $db->single('mock_inflate',{id => 1});
+        my $hash = $row->hash;
+        $hash->{x} = 'bar';
+        $row->update;
+        is ref($row->hash), 'HASH';
+        is $row->hash->{x}, 'bar';
     }
 };
 

--- a/t/001_basic/011_inflate.t
+++ b/t/001_basic/011_inflate.t
@@ -125,5 +125,37 @@ subtest 'insert/update on non existent table' => sub {
     like $@, qr/Table definition for mock_inflate_non_existent2 does not exist \(Did you declare it in our schema\?\)/;
 };
 
+subtest 'update column name' => sub {
+    # set method
+    {
+        my $row = $db->single('mock_inflate',{id => 1});
+        $row->set(hash => { x => 'foo' });
+        $row->update;
+        is ref($row->hash), 'HASH';
+        is $row->hash->{x}, 'foo';
+    }
+    {
+        my $row = $db->single('mock_inflate',{id => 1});
+        is ref($row->hash), 'HASH';
+        is $row->hash->{x}, 'foo';
+    }
+
+    # column name
+    {
+        my $row = $db->single('mock_inflate',{id => 1});
+        $row->hash({ x => 'foo' });
+        $row->update;
+        is ref($row->hash), 'HASH';
+        is $row->hash->{x}, 'foo';
+    }
+    {
+        my $row = $db->single('mock_inflate',{id => 1});
+        use Data::Dumper;
+        warn Dumper $row->hash ;
+        is ref($row->hash), 'HASH';
+        is $row->hash->{x}, 'foo';
+    }
+};
+
 done_testing;
 

--- a/t/lib/Mock/Inflate.pm
+++ b/t/lib/Mock/Inflate.pm
@@ -13,6 +13,7 @@ sub setup_test_db {
                 name TEXT,
                 foo  TEXT,
                 bar  TEXT,
+                hash TEXT,
                 PRIMARY KEY  (id, bar)
             )
         });
@@ -26,6 +27,7 @@ sub setup_test_db {
                 name      TEXT,
                 foo       TEXT,
                 bar       VARCHAR(32),
+                hash      TEXT,
                 PRIMARY KEY  (id, bar)
             ) ENGINE=InnoDB
         });

--- a/t/lib/Mock/Inflate/Schema.pm
+++ b/t/lib/Mock/Inflate/Schema.pm
@@ -7,7 +7,7 @@ use Mock::Inflate::Name;
 table {
     name 'mock_inflate';
     pk qw/ id bar /;
-    columns qw/ id name foo bar /;
+    columns qw/ id name foo bar hash /;
     inflate 'name' => sub {
         my ($col_value) = @_;
         return Mock::Inflate::Name->new(name => $col_value);
@@ -31,6 +31,14 @@ table {
     deflate 'bar' => sub {
         my ($col_value) = @_;
         return ref $col_value ? $col_value->name : $col_value . '_deflate';
+    };
+    inflate 'hash' => sub {
+        my ($col_value) = @_;
+        return { x => $col_value };
+    };
+    deflate 'hash' => sub {
+        my ($col_value) = @_;
+        return $col_value->{x};
     };
 };
 


### PR DESCRIPTION
0.18 -> 0.19 で Teng::Row をリファクタしたタイミングで、set_column (や、これを使うカラム名メソッドなど) の挙動が変わっているとの指摘があった。

経緯をよく覚えてないが、挙動が変わったことは確かなようなので、0.18 以前では通るテストを追加し、0.19 以降のユーザとの兼ね合いから set_column で強制的に deflate させる force_deflate_set_column オプションを追加した。