### PR TITLE
Fix Temg::Row#set_column ignores to set original value again

### DIFF
--- a/lib/Teng/Row.pm
+++ b/lib/Teng/Row.pm
@@ -104,6 +104,11 @@ sub set_column {
     if ( defined $self->{row_data}->{$col} 
       && defined $val 
       && $self->{row_data}->{$col} eq $val ) {
+        if (exists $self->{_dirty_columns}->{$col}) {
+            delete $self->{_dirty_columns}->{$col};
+            delete $self->{_get_column_cached}->{$col};
+            delete $self->{_untrusted_row_data}->{$col};
+        }
         return $val;
     }
 

--- a/t/002_common/002_update.t
+++ b/t/002_common/002_update.t
@@ -162,4 +162,21 @@ subtest 'do not update with where cond' => sub {
     is $row2->name, 'perl6';
 };
 
+subtest 'set original value again before update' => sub {
+    my $row = $db->single('mock_basic',{
+        id => 1,
+    });
+    is $row->name, 'perl6';
+
+    $row->name('raku');
+    ok $row->is_changed;
+    is $row->name, 'raku';
+
+    $row->name('perl6');
+    ok !$row->is_changed;
+
+    is $row->update, 0;
+    is $row->name, 'perl6';
+};
+
 done_testing;


### PR DESCRIPTION
いまの Teng::Row が、`$row` にあたらしい値をセットしてから、一度 `update()` する前に再度元のカラム値と同じ値をセットすると、その値は反映されない。  
で `update()` を呼び出してしまうと、最初にセットされた値で更新されてしまう。

```
say $row->col;  # "foo"
my $orig = $row->col;
$row->col("bar");
$row->col($orig); # set "foo" again
say $row->col;  # "bar" <- ?
```

…という挙動にハマって、これバグじゃないのかしら？と感じたので pull request します。
