### PR TITLE
Add default_row_class_prefix option to Teng::Schema::Dumper

### DIFF
--- a/lib/Teng/Schema/Dumper.pm
+++ b/lib/Teng/Schema/Dumper.pm
@@ -33,6 +33,7 @@ sub dump {
         $ret .= "use DBI qw/:sql_types/;\n";
         $ret .= "use Teng::Schema::Declare;\n";
         $ret .= "base_row_class '$args{base_row_class}';\n" if $args{base_row_class};
+        $ret .= "default_row_class_prefix '$args{default_row_class_prefix}';\n" if $args{default_row_class_prefix};
         for my $table_info (sort { $a->name cmp $b->name } $inspector->tables) {
             $ret .= _render_table($table_info, \%args);
         }
@@ -137,6 +138,10 @@ your project Teng namespace.
 =item C<base_row_class>
 
 Specify the default base row class for L<Teng::Schema::Declare>.
+
+=item C<default_row_class_prefix>
+
+Specify the default row class prefix for L<Teng::Schema::Declare>.
 
 =back
 

--- a/t/001_basic/004_schema_dumper.t
+++ b/t/001_basic/004_schema_dumper.t
@@ -113,5 +113,15 @@ subtest "dump with base_row_class" => sub {
     note $code;
     like $code, qr/base_row_class 'Mock::DB::Row';\n/;
 };
+subtest "dump with default_row_class_prefix" => sub {
+    # generate schema and eval.
+    my $code = Teng::Schema::Dumper->dump(
+        dbh                      => $dbh,
+        namespace                => 'Mock::DB',
+        default_row_class_prefix => 'My::Entity',
+    );
+    note $code;
+    like $code, qr/default_row_class_prefix 'My::Entity';\n/;
+};
 
 done_testing;


### PR DESCRIPTION
`Teng::Schema::Declare#default_row_class_prefix` was added in #141,
but Teng::Schema::Dumper has no option to print it.

This makes problem if I am checking the diff between the committed schema and the dump from the latest DB in CI.