### PR TITLE
Extract trace_query_set_comment

### DIFF
--- a/t/001_basic/037_trace_query_set_comment.t
+++ b/t/001_basic/037_trace_query_set_comment.t
@@ -1,0 +1,27 @@
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use t::Utils;
+use Mock::Basic;
+use Test::More;
+
+my $dbh = t::Utils->setup_dbh;
+my $db_basic = Mock::Basic->new({dbh => $dbh});
+$db_basic->setup_test_db;
+
+subtest 'trace_query_set_comment method' => sub {
+    local $ENV{TENG_SQL_COMMENT} = 1;
+
+    subtest 'SQL_COMMENT_LEVEL = 1 (default)' => sub {
+        my $sth = $db_basic->execute('SELECT * FROM mock_basic'); my ($file, $line) = (__FILE__, __LINE__);
+        is $sth->{Statement}, "/* $file at line $line */\nSELECT * FROM mock_basic";
+    };
+
+    subtest 'SQL_COMMENT_LEVEL = 2' => sub {
+        local $Teng::SQL_COMMENT_LEVEL = 2;
+        my $func = sub { $db_basic->execute('SELECT * FROM mock_basic') };
+        my $sth = $func->(); my ($file, $line) = (__FILE__, __LINE__);
+        is $sth->{Statement}, "/* $file at line $line */\nSELECT * FROM mock_basic";
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Executing SQL and adding comment to SQL are different roles.

With this change, the stacktrace is +1 deeper.
This is the BREAKING CHANGE to existing code that uses `SQL_COMMENT_LEVEL`.
They need to increment `SQL_COMMENT_LEVEL` by +1.

---

* The method name comes from DBIx::Handler
  - https://github.com/nekokak/p5-DBIx-Handler/blob/0.15/lib/DBIx/Handler.pm#L204-L219
* I want to override the caller filter. This is the trigger for this PR
  - I plan to support `trace_ignore_if` in following PR
  - My problem is solved with just `trace_ignore_if`, but I think extract method is better code