### PR TITLE
Don't update when set column from null to null

### DIFF
--- a/lib/Teng/Row.pm
+++ b/lib/Teng/Row.pm
@@ -101,9 +101,9 @@ sub set_column {
         $val = $self->{table}->call_deflate($col, $val);
     }
 
-    if ( defined $self->{row_data}->{$col} 
-      && defined $val 
-      && $self->{row_data}->{$col} eq $val ) {
+    my $has_same_value =  defined $self->{row_data}->{$col} &&  defined $val && $self->{row_data}->{$col} eq $val;
+    my $both_are_undef     = !defined $self->{row_data}->{$col} && !defined $val;
+    if ($has_same_value || $both_are_undef) {
         if (exists $self->{_dirty_columns}->{$col}) {
             delete $self->{_dirty_columns}->{$col};
             delete $self->{_get_column_cached}->{$col};

--- a/t/002_common/002_update.t
+++ b/t/002_common/002_update.t
@@ -181,4 +181,31 @@ subtest 'set original value again before update' => sub {
     is $row->name, 'perl6';
 };
 
+subtest 'set null again before update' => sub {
+    $db->insert('mock_basic',{
+        id   => 4,
+        name => undef,
+    });
+    my $row = $db->single('mock_basic',{
+        id => 4,
+    });
+    is $row->name, undef;
+
+    # undef to undef
+    $row->name(undef);
+    ok !$row->is_changed;
+    is $row->update, 0;
+
+    # undef to string
+    $row->name('php');
+    ok $row->is_changed;
+    is $row->update, 1;
+
+    # string to undef
+    $row->name(undef);
+    ok $row->is_changed;
+    is $row->update, 1;
+
+};
+
 done_testing;


### PR DESCRIPTION
- If you set_column the value of Row, we should avoid update.
- However, if you set_column from undef to undef, it will be updated unexpectedly.
- This PR checks both values are same, or both values are undef to determine it is changed value.

Before e80d69a, the test I added was failed.

```
root@b210ea80bcbb:/app# prove -l t/002_common/002_update.t
t/002_common/002_update.t .. 1/?
    #   Failed test at t/002_common/002_update.t line 196.

    #   Failed test at t/002_common/002_update.t line 197.
    #          got: '1'
    #     expected: '0'
    # Looks like you failed 2 tests of 7.

#   Failed test 'set null again before update'
#   at t/002_common/002_update.t line 209.
# Looks like you failed 1 test of 13.
t/002_common/002_update.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/13 subtests

Test Summary Report
-------------------
t/002_common/002_update.t (Wstat: 256 Tests: 13 Failed: 1)
  Failed test:  13
  Non-zero exit status: 1
Files=1, Tests=13,  1 wallclock secs ( 0.01 usr  0.02 sys +  0.06 cusr  0.03 csys =  0.12 CPU)
Result: FAIL
```