### PR TITLE
Fix mismatch of pager class name between implementation and documents

### DIFF
--- a/lib/Teng/Plugin/Pager/MySQLFoundRows.pm
+++ b/lib/Teng/Plugin/Pager/MySQLFoundRows.pm
@@ -102,7 +102,7 @@ The number of entries per page.
 
 =back
 
-This method returns ArrayRef[Teng::Row] and instance of L<Teng::Plugin::Pager::Page>.
+This method returns ArrayRef[Teng::Row] and instance of L<Data::Page>.
 
 =back
 


### PR DESCRIPTION
## Problem

In document[^1]:

> This method returns ArrayRef[Teng::Row] and instance of [Teng::Plugin::Pager::Page](https://metacpan.org/pod/Teng::Plugin::Pager::Page).

In current implementation[^2]:

```perl
    my $pager = Data::Page->new();
    $pager->entries_per_page($rows);
    $pager->current_page($page);
    $pager->total_entries($total_entries);

    return ([$itr->all], $pager);
```



It might be confusing.

[^1]: https://metacpan.org/release/NEKOKAK/Teng-0.17/view/lib/Teng/Plugin/Pager/MySQLFoundRows.pm#:~:text=This%20method%20returns%20ArrayRef%5BTeng%3A%3ARow%5D%20and%20instance%20of%20Teng%3A%3APlugin%3A%3APager%3A%3APage.
[^2]: https://github.com/nekokak/p5-Teng/blob/master/lib/Teng/Plugin/Pager/MySQLFoundRows.pm#L49-L54

## Solution

Simply fixed the pod.

## Appendix

- This mismatch appeared in original commit of this module: https://github.com/nekokak/p5-Teng/commit/149f16edb8998b1932ef4fdedd2c40cecc3a75db
- `DBIx::Skin::Plugin::Pager::Page` renamed to `Teng::Plugin::Pager::Page` here: https://github.com/nekokak/p5-Teng/commit/c42dee20dbd3b9022beec94ba372c63e904c5ac6


